### PR TITLE
BUGFIX #5: Fixes many_to_many kwarg error (continued)

### DIFF
--- a/django_fulltext_search.py
+++ b/django_fulltext_search.py
@@ -3,7 +3,7 @@ from django.db import models, connection
 
 __author__ = 'confirm IT solutions'
 __email__ = 'contactus@confirm.ch'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 
 class SearchQuerySet(models.query.QuerySet):
@@ -72,7 +72,7 @@ class SearchQuerySet(models.query.QuerySet):
             # Handle fields without a related model.
             else:
                 table  = meta.db_table
-                column = meta.get_field(field, many_to_many=False).column
+                column = meta.get_field(field).column
 
             # Add field with `table`.`column` style to columns set.
             columns.add('{}.{}'.format(quote_name(table), quote_name(column)))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-version = "0.2.0"
+version = "0.2.1"
 
 if sys.argv[-1] == 'publish':
     try:


### PR DESCRIPTION
I was still getting the following error:

`TypeError: get_field() got an unexpected keyword argument 'many_to_many'`

I took inspiration from commit 0544c8bcb129471310e8114fa7bbb099848ed411 and made the same changes, only a couple lines below.